### PR TITLE
fix: raise SlugGenerationError when slug retry limit is exhausted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev install-test install-testing clean lint format sort-imports type-check quality test test-verbose coverage clean-build clean-pyc clean-test docs docs-clean all check
+.PHONY: help init install install-dev install-test install-testing clean lint format sort-imports type-check quality test test-verbose coverage clean-build clean-pyc clean-test docs docs-clean all check
 
 PYTHON ?= .venv/bin/python
 
@@ -38,6 +38,12 @@ help:
 	@echo "  check         Run quality checks and tests (CI-friendly)"
 
 # Setup & Installation
+init:
+	python3 -m venv .venv
+	.venv/bin/pip install --upgrade pip
+	.venv/bin/pip install -e .[dev,test,build,import,export,debug]
+	@echo "Virtual environment initialised at .venv/"
+
 install:
 	$(PYTHON) -m pip install -e .
 

--- a/drf_commons/models/__init__.py
+++ b/drf_commons/models/__init__.py
@@ -28,6 +28,7 @@ from .mixins import JsonModelMixin
 # Content-related mixins
 from .content import (
     MetaMixin,
+    SlugGenerationError,
     SlugMixin,
     VersionMixin,
 )
@@ -51,6 +52,7 @@ __all__ = [
     "SoftDeleteMixin",
     "JsonModelMixin",
     # Content mixins
+    "SlugGenerationError",
     "SlugMixin",
     "MetaMixin",
     "VersionMixin",

--- a/drf_commons/models/content.py
+++ b/drf_commons/models/content.py
@@ -16,6 +16,10 @@ class VersionConflictError(Exception):
     """Raised when a versioned model update conflicts with a concurrent write."""
 
 
+class SlugGenerationError(Exception):
+    """Raised when a unique slug cannot be generated within the retry limit."""
+
+
 class SlugMixin(models.Model):
     """
     Mixin that provides automatic slug generation functionality.
@@ -55,15 +59,27 @@ class SlugMixin(models.Model):
 
     def generate_slug(self) -> str:
         """
-        Generate the base deterministic slug candidate.
+        Generate a unique slug, retrying with numeric suffixes on conflict.
 
         Returns:
-            Base slug candidate string
+            Unique slug string
+
+        Raises:
+            SlugGenerationError: If a unique slug cannot be found within the retry limit
         """
         base_slug = slugify(self.get_slug_source())
         if not base_slug:
             base_slug = "item"
-        return self._build_slug_candidate(base_slug, 0)
+
+        for attempt in range(self.slug_conflict_retry_limit):
+            candidate = self._build_slug_candidate(base_slug, attempt)
+            if not self.__class__._default_manager.filter(slug=candidate).exclude(pk=self.pk).exists():
+                return candidate
+
+        raise SlugGenerationError(
+            f"Could not generate a unique slug for {self.__class__.__name__} "
+            f"after {self.slug_conflict_retry_limit} attempts."
+        )
 
     def _build_slug_candidate(self, base_slug: str, attempt: int) -> str:
         """Build deterministic slug candidate for retry attempts."""

--- a/tests/models/test_content.py
+++ b/tests/models/test_content.py
@@ -9,7 +9,7 @@ from django.utils.text import slugify
 
 from drf_commons.common_tests.base_cases import DrfCommonTransactionTestCase, ModelTestCase
 
-from drf_commons.models.content import MetaMixin, SlugMixin, VersionConflictError, VersionMixin
+from drf_commons.models.content import MetaMixin, SlugGenerationError, SlugMixin, VersionConflictError, VersionMixin
 
 
 class SlugModelForTesting(SlugMixin):
@@ -113,7 +113,19 @@ class SlugMixinTests(DrfCommonTransactionTestCase):
         model = SlugModelForTesting(title="Test Title")
         slug = model.generate_slug()
 
-        self.assertEqual(slug, "test-title")
+        self.assertEqual(slug, "test-title-2")
+
+    def test_generate_slug_raises_when_retry_limit_exhausted(self):
+        """Test generate_slug raises SlugGenerationError when all candidates are taken."""
+        limit = SlugModelForTesting.slug_conflict_retry_limit
+        for i in range(limit):
+            suffix = "" if i == 0 else f"-{i}"
+            SlugModelForTesting.objects.create(title=f"Filler {i}", slug=f"test-title{suffix}")
+
+        model = SlugModelForTesting(title="Test Title")
+
+        with self.assertRaises(SlugGenerationError):
+            model.generate_slug()
 
     def test_generate_slug_excludes_current_instance(self):
         """Test generate_slug excludes current instance from conflict check."""


### PR DESCRIPTION
## Summary

- Adds `SlugGenerationError` exception raised when `generate_slug()` cannot find a unique slug within `slug_conflict_retry_limit` attempts (default: 20)
- Rewrites `generate_slug()` to loop over candidates, checking DB uniqueness on each attempt and raising on exhaustion instead of silently returning a conflicting slug
- Exports `SlugGenerationError` from `drf_commons.models` so callers can catch it without knowing the internal module path
- Fixes the broken `test_generate_slug_with_conflicts` assertion (expected `"test-title"` when both `"test-title"` and `"test-title-1"` were already taken)
- Adds `test_generate_slug_raises_when_retry_limit_exhausted` test
- Adds `make init` target to bootstrap the virtual environment

## Test plan

- [x] All 49 existing tests pass
- [x] `test_generate_slug_with_conflicts` now correctly expects `"test-title-2"`
- [x] `test_generate_slug_raises_when_retry_limit_exhausted` confirms `SlugGenerationError` is raised when all candidates are taken

Closes #14